### PR TITLE
Sign transaction

### DIFF
--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -106,9 +106,9 @@ message CardanoSignTx {
      * Structure representing cardano transaction output
      */
     message CardanoTxOutputType {
-        optional string address = 1;    // target coin address in Base58 encoding
-        repeated uint32 address_n = 2;  // BIP-32 path to derive the key from master node; has higher priority than "address"
-        optional uint64 amount = 3;     // amount to spend
+        optional string address = 1;                                    // address in Base58/Bech32 encoding
+        optional CardanoAddressParametersType address_parameters = 2;   // parameters used to derive the address
+        optional uint64 amount = 3;                                     // amount to spend
     }
 }
 

--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -85,16 +85,14 @@ message CardanoPublicKey {
  * Request: Ask device to sign Cardano transaction
  * @start
  * @next CardanoSignedTx
- * @next CardanoTxRequest
  * @next Failure
  */
 message CardanoSignTx {
     repeated CardanoTxInputType inputs = 1;     // inputs to be used in transaction
     repeated CardanoTxOutputType outputs = 2;   // outputs to be used in transaction
-    optional uint32 transactions_count = 3;     // transactions count
-    optional uint32 protocol_magic = 5;         // network's protocol magic
-    optional uint32 fee = 6;                    // transaction fee - added in shelley
-    optional uint32 ttl = 7;                    // transaction ttl - added in shelley
+    optional uint32 protocol_magic = 3;         // network's protocol magic
+    optional uint32 fee = 4;                    // transaction fee - added in shelley
+    optional uint32 ttl = 5;                    // transaction ttl - added in shelley
     /**
      * Structure representing cardano transaction input
      */

--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -93,6 +93,8 @@ message CardanoSignTx {
     repeated CardanoTxOutputType outputs = 2;   // outputs to be used in transaction
     optional uint32 transactions_count = 3;     // transactions count
     optional uint32 protocol_magic = 5;         // network's protocol magic
+    optional uint32 fee = 6;                    // transaction fee - added in shelley
+    optional uint32 ttl = 7;                    // transaction ttl - added in shelley
     /**
      * Structure representing cardano transaction input
      */

--- a/core/src/apps/cardano/address.py
+++ b/core/src/apps/cardano/address.py
@@ -1,5 +1,5 @@
 from trezor import wire
-from trezor.crypto import hashlib
+from trezor.crypto import base58, hashlib
 from trezor.messages import CardanoAddressType, CardanoCertificatePointerType
 
 import apps.cardano.address_id as AddressId
@@ -48,25 +48,37 @@ def get_human_readable_address(address: bytes) -> str:
 
 
 def derive_address(
-    keychain: seed.Keychain, parameters: CardanoAddressParametersType, network_id: int
+    keychain: seed.Keychain,
+    parameters: CardanoAddressParametersType,
+    network_id: int,
+    human_readable: bool = True,
 ) -> str:
+    if parameters.address_type == CardanoAddressType.BOOTSTRAP_ADDRESS:
+        address = _derive_bootstrap_address(keychain, parameters.address_n)
+        if human_readable:
+            return address
+        else:
+            return base58.decode(address)
+
     if parameters.address_type == CardanoAddressType.BASE_ADDRESS:
-        return derive_base_address(
+        address = _derive_base_address(
             keychain, parameters.address_n, network_id, parameters.staking_key_hash
         )
     elif parameters.address_type == CardanoAddressType.ENTERPRISE_ADDRESS:
-        return derive_enterprise_address(keychain, parameters.address_n, network_id)
+        address = _derive_enterprise_address(keychain, parameters.address_n, network_id)
     elif parameters.address_type == CardanoAddressType.POINTER_ADDRESS:
-        return derive_pointer_address(
+        address =  _derive_pointer_address(
             keychain, parameters.address_n, network_id, parameters.certificate_pointer,
         )
-    elif parameters.address_type == CardanoAddressType.BOOTSTRAP_ADDRESS:
-        return derive_bootstrap_address(keychain, parameters.address_n)
     else:
         raise ValueError("Invalid address type '%s'" % parameters.address_type)
 
+    if human_readable:
+        return get_human_readable_address(address)
+    else:
+        return address
 
-def derive_base_address(
+def _derive_base_address(
     keychain: seed.Keychain, path: list, network_id: int, staking_key_hash: bytes
 ) -> str:
     if not _validate_shelley_address_path(path):
@@ -82,10 +94,10 @@ def derive_base_address(
     address_header = _get_address_header(CardanoAddressType.BASE_ADDRESS, network_id)
     address = address_header + spending_part + staking_part
 
-    return get_human_readable_address(address)
+    return address
 
 
-def derive_pointer_address(
+def _derive_pointer_address(
     keychain: seed.Keychain,
     path: list,
     network_id: int,
@@ -100,10 +112,10 @@ def derive_pointer_address(
     encoded_pointer = _encode_certificate_pointer(pointer)
     address = address_header + spending_part + encoded_pointer
 
-    return get_human_readable_address(address)
+    return address
 
 
-def derive_enterprise_address(keychain: seed.Keychain, path: list, network_id: int) -> str:
+def _derive_enterprise_address(keychain: seed.Keychain, path: list, network_id: int) -> str:
     if not _validate_shelley_address_path(path):
         raise wire.DataError("Invalid path for enterprise address")
 
@@ -114,10 +126,10 @@ def derive_enterprise_address(keychain: seed.Keychain, path: list, network_id: i
     )
     address = address_header + spending_part
 
-    return get_human_readable_address(address)
+    return address
 
 
-def derive_bootstrap_address(keychain: seed.Keychain, path: list) -> str:
+def _derive_bootstrap_address(keychain: seed.Keychain, path: list) -> str:
     if not _validate_bootstrap_address_path(path):
         raise wire.DataError("Invalid path for bootstrap address")
 

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -115,18 +115,19 @@ class Transaction:
         change_coins = []
 
         for output in self.outputs:
-            if output.address_n:
-                address, _ = derive_address_and_node(self.keychain, output.address_n)
+            if output.output.address_parameters:
+                address, _ = derive_address_and_node(self.keychain, output.address_parameters.address_n)
                 change_addresses.append(address)
-                change_derivation_paths.append(output.address_n)
+                change_derivation_paths.append(output.address_parameters.address_n)
                 change_coins.append(output.amount)
             else:
                 if output.address is None:
                     raise wire.ProcessError(
                         "Each output must have address or address_n field!"
                     )
-                if not is_safe_output_address(output.address):
-                    raise wire.ProcessError("Invalid output address!")
+                # todo: GK - this should be checked only with byron addresses
+                # if not is_safe_output_address(output.address):
+                #     raise wire.ProcessError("Invalid output address!")
 
                 outgoing_coins.append(output.amount)
                 output_addresses.append(output.address)

--- a/core/src/trezor/messages/CardanoSignTx.py
+++ b/core/src/trezor/messages/CardanoSignTx.py
@@ -22,11 +22,15 @@ class CardanoSignTx(p.MessageType):
         outputs: List[CardanoTxOutputType] = None,
         transactions_count: int = None,
         protocol_magic: int = None,
+        fee: int = None,
+        ttl: int = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
         self.transactions_count = transactions_count
         self.protocol_magic = protocol_magic
+        self.fee = fee
+        self.ttl = ttl
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -35,4 +39,6 @@ class CardanoSignTx(p.MessageType):
             2: ('outputs', CardanoTxOutputType, p.FLAG_REPEATED),
             3: ('transactions_count', p.UVarintType, 0),
             5: ('protocol_magic', p.UVarintType, 0),
+            6: ('fee', p.UVarintType, 0),
+            7: ('ttl', p.UVarintType, 0),
         }

--- a/core/src/trezor/messages/CardanoSignTx.py
+++ b/core/src/trezor/messages/CardanoSignTx.py
@@ -20,14 +20,12 @@ class CardanoSignTx(p.MessageType):
         self,
         inputs: List[CardanoTxInputType] = None,
         outputs: List[CardanoTxOutputType] = None,
-        transactions_count: int = None,
         protocol_magic: int = None,
         fee: int = None,
         ttl: int = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
-        self.transactions_count = transactions_count
         self.protocol_magic = protocol_magic
         self.fee = fee
         self.ttl = ttl
@@ -37,8 +35,7 @@ class CardanoSignTx(p.MessageType):
         return {
             1: ('inputs', CardanoTxInputType, p.FLAG_REPEATED),
             2: ('outputs', CardanoTxOutputType, p.FLAG_REPEATED),
-            3: ('transactions_count', p.UVarintType, 0),
-            5: ('protocol_magic', p.UVarintType, 0),
-            6: ('fee', p.UVarintType, 0),
-            7: ('ttl', p.UVarintType, 0),
+            3: ('protocol_magic', p.UVarintType, 0),
+            4: ('fee', p.UVarintType, 0),
+            5: ('ttl', p.UVarintType, 0),
         }

--- a/core/src/trezor/messages/CardanoTxOutputType.py
+++ b/core/src/trezor/messages/CardanoTxOutputType.py
@@ -2,6 +2,8 @@
 # fmt: off
 import protobuf as p
 
+from .CardanoAddressParametersType import CardanoAddressParametersType
+
 if __debug__:
     try:
         from typing import Dict, List  # noqa: F401
@@ -15,17 +17,17 @@ class CardanoTxOutputType(p.MessageType):
     def __init__(
         self,
         address: str = None,
-        address_n: List[int] = None,
+        address_parameters: CardanoAddressParametersType = None,
         amount: int = None,
     ) -> None:
         self.address = address
-        self.address_n = address_n if address_n is not None else []
+        self.address_parameters = address_parameters
         self.amount = amount
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('address', p.UnicodeType, 0),
-            2: ('address_n', p.UVarintType, p.FLAG_REPEATED),
+            2: ('address_parameters', CardanoAddressParametersType, 0),
             3: ('amount', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/cardano.py
+++ b/python/src/trezorlib/cardano.py
@@ -46,7 +46,6 @@ def sign_tx(
     client,
     inputs: List[messages.CardanoTxInputType],
     outputs: List[messages.CardanoTxOutputType],
-    transactions: List[bytes],
     fee: int,
     ttl: int,
     protocol_magic,
@@ -55,19 +54,11 @@ def sign_tx(
         messages.CardanoSignTx(
             inputs=inputs,
             outputs=outputs,
-            transactions_count=len(transactions),
             fee=fee,
             ttl=ttl,
             protocol_magic=protocol_magic,
         )
     )
-
-    while isinstance(response, messages.CardanoTxRequest):
-        tx_index = response.tx_index
-
-        transaction_data = bytes.fromhex(transactions[tx_index])
-        ack_message = messages.CardanoTxAck(transaction=transaction_data)
-        response = client.call(ack_message)
 
     return response
 

--- a/python/src/trezorlib/cardano.py
+++ b/python/src/trezorlib/cardano.py
@@ -47,6 +47,8 @@ def sign_tx(
     inputs: List[messages.CardanoTxInputType],
     outputs: List[messages.CardanoTxOutputType],
     transactions: List[bytes],
+    fee: int,
+    ttl: int,
     protocol_magic,
 ):
     response = client.call(
@@ -54,6 +56,8 @@ def sign_tx(
             inputs=inputs,
             outputs=outputs,
             transactions_count=len(transactions),
+            fee=fee,
+            ttl=ttl,
             protocol_magic=protocol_magic,
         )
     )

--- a/python/src/trezorlib/cardano.py
+++ b/python/src/trezorlib/cardano.py
@@ -22,6 +22,8 @@ from .tools import expect, session
 REQUIRED_FIELDS_TRANSACTION = ("inputs", "outputs", "transactions")
 REQUIRED_FIELDS_INPUT = ("path", "prev_hash", "prev_index", "type")
 
+INCOMPLETE_OUTPUT_ERROR_MESSAGE = "The output is missing some fields"
+
 
 @expect(messages.CardanoAddress, field="address")
 def get_address(
@@ -103,16 +105,82 @@ def create_input(input) -> messages.CardanoTxInputType:
 
 
 def create_output(output) -> messages.CardanoTxOutputType:
-    if not output.get("amount") or not (output.get("address") or output.get("path")):
-        raise ValueError("The output is missing some fields")
+    contains_address = output.get("address")
+    # None check needed, because address type can be 0, thus this would be False
+    # even though 0 is a valid value
+    contains_address_type = output.get("addressType") is not None
 
-    if output.get("path"):
-        path = output["path"]
+    if not output.get("amount"):
+        raise ValueError(INCOMPLETE_OUTPUT_ERROR_MESSAGE)
+    if not (contains_address or contains_address_type):
+        raise ValueError(INCOMPLETE_OUTPUT_ERROR_MESSAGE)
+
+    if contains_address:
+        return messages.CardanoTxOutputType(
+            address=output["address"], amount=int(output["amount"])
+        )
+    else:
+        return _create_change_address_output(output)
+
+
+def _create_change_address_output(output) -> messages.CardanoTxOutputType:
+    # every address type requires a path, so check it only once
+    if not output.get("path"):
+        raise ValueError(INCOMPLETE_OUTPUT_ERROR_MESSAGE)
+
+    path = output["path"]
+    address_type = int(output["addressType"])
+
+    if address_type == messages.CardanoAddressType.BASE_ADDRESS:
+        if output.get("stakingKeyHash"):
+            staking_key_hash = bytes.fromhex(output["stakingKeyHash"])
+        else:
+            staking_key_hash = None
 
         return messages.CardanoTxOutputType(
-            address_n=tools.parse_path(path), amount=int(output["amount"])
+            address_parameters=messages.CardanoAddressParametersType(
+                address_type=address_type,
+                address_n=tools.parse_path(path),
+                staking_key_hash=staking_key_hash,
+            ),
+            amount=int(output["amount"]),
         )
+    elif address_type == messages.CardanoAddressType.POINTER_ADDRESS:
+        if not output.get("pointer"):
+            raise ValueError(INCOMPLETE_OUTPUT_ERROR_MESSAGE)
 
-    return messages.CardanoTxOutputType(
-        address=output["address"], amount=int(output["amount"])
-    )
+        pointer = output["pointer"]
+
+        # None check needed, because the values can be 0, thus the result would be False
+        # even though 0 is a valid value
+        if (
+            pointer.get("block_index") is None
+            or pointer.get("tx_index") is None
+            or pointer.get("certificate_index") is None
+        ):
+            raise ValueError(INCOMPLETE_OUTPUT_ERROR_MESSAGE)
+
+        return messages.CardanoTxOutputType(
+            address_parameters=messages.CardanoAddressParametersType(
+                address_type=address_type,
+                address_n=tools.parse_path(path),
+                certificate_pointer=messages.CardanoCertificatePointerType(
+                    block_index=pointer["block_index"],
+                    tx_index=pointer["tx_index"],
+                    certificate_index=pointer["certificate_index"],
+                ),
+            ),
+            amount=int(output["amount"]),
+        )
+    elif (
+        address_type == messages.CardanoAddressType.ENTERPRISE_ADDRESS
+        or address_type == messages.CardanoAddressType.BOOTSTRAP_ADDRESS
+    ):
+        return messages.CardanoTxOutputType(
+            address_parameters=messages.CardanoAddressParametersType(
+                address_type=address_type, address_n=tools.parse_path(path),
+            ),
+            amount=int(output["amount"]),
+        )
+    else:
+        raise ValueError("Unknown address type")

--- a/python/src/trezorlib/cli/cardano.py
+++ b/python/src/trezorlib/cli/cardano.py
@@ -45,11 +45,10 @@ def sign_tx(client, file, network):
 
     inputs = [cardano.create_input(input) for input in transaction["inputs"]]
     outputs = [cardano.create_output(output) for output in transaction["outputs"]]
-    transactions = transaction["transactions"]
     fee = transaction["fee"]
     ttl = transaction["ttl"]
 
-    signed_transaction = cardano.sign_tx(client, inputs, outputs, transactions, fee, ttl, network)
+    signed_transaction = cardano.sign_tx(client, inputs, outputs, fee, ttl, network)
 
     return {
         "tx_hash": signed_transaction.tx_hash.hex(),

--- a/python/src/trezorlib/cli/cardano.py
+++ b/python/src/trezorlib/cli/cardano.py
@@ -46,8 +46,10 @@ def sign_tx(client, file, network):
     inputs = [cardano.create_input(input) for input in transaction["inputs"]]
     outputs = [cardano.create_output(output) for output in transaction["outputs"]]
     transactions = transaction["transactions"]
+    fee = transaction["fee"]
+    ttl = transaction["ttl"]
 
-    signed_transaction = cardano.sign_tx(client, inputs, outputs, transactions, network)
+    signed_transaction = cardano.sign_tx(client, inputs, outputs, transactions, fee, ttl, network)
 
     return {
         "tx_hash": signed_transaction.tx_hash.hex(),

--- a/python/src/trezorlib/messages/CardanoSignTx.py
+++ b/python/src/trezorlib/messages/CardanoSignTx.py
@@ -22,11 +22,15 @@ class CardanoSignTx(p.MessageType):
         outputs: List[CardanoTxOutputType] = None,
         transactions_count: int = None,
         protocol_magic: int = None,
+        fee: int = None,
+        ttl: int = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
         self.transactions_count = transactions_count
         self.protocol_magic = protocol_magic
+        self.fee = fee
+        self.ttl = ttl
 
     @classmethod
     def get_fields(cls) -> Dict:
@@ -35,4 +39,6 @@ class CardanoSignTx(p.MessageType):
             2: ('outputs', CardanoTxOutputType, p.FLAG_REPEATED),
             3: ('transactions_count', p.UVarintType, 0),
             5: ('protocol_magic', p.UVarintType, 0),
+            6: ('fee', p.UVarintType, 0),
+            7: ('ttl', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/messages/CardanoSignTx.py
+++ b/python/src/trezorlib/messages/CardanoSignTx.py
@@ -20,14 +20,12 @@ class CardanoSignTx(p.MessageType):
         self,
         inputs: List[CardanoTxInputType] = None,
         outputs: List[CardanoTxOutputType] = None,
-        transactions_count: int = None,
         protocol_magic: int = None,
         fee: int = None,
         ttl: int = None,
     ) -> None:
         self.inputs = inputs if inputs is not None else []
         self.outputs = outputs if outputs is not None else []
-        self.transactions_count = transactions_count
         self.protocol_magic = protocol_magic
         self.fee = fee
         self.ttl = ttl
@@ -37,8 +35,7 @@ class CardanoSignTx(p.MessageType):
         return {
             1: ('inputs', CardanoTxInputType, p.FLAG_REPEATED),
             2: ('outputs', CardanoTxOutputType, p.FLAG_REPEATED),
-            3: ('transactions_count', p.UVarintType, 0),
-            5: ('protocol_magic', p.UVarintType, 0),
-            6: ('fee', p.UVarintType, 0),
-            7: ('ttl', p.UVarintType, 0),
+            3: ('protocol_magic', p.UVarintType, 0),
+            4: ('fee', p.UVarintType, 0),
+            5: ('ttl', p.UVarintType, 0),
         }

--- a/python/src/trezorlib/messages/CardanoTxOutputType.py
+++ b/python/src/trezorlib/messages/CardanoTxOutputType.py
@@ -2,6 +2,8 @@
 # fmt: off
 from .. import protobuf as p
 
+from .CardanoAddressParametersType import CardanoAddressParametersType
+
 if __debug__:
     try:
         from typing import Dict, List  # noqa: F401
@@ -15,17 +17,17 @@ class CardanoTxOutputType(p.MessageType):
     def __init__(
         self,
         address: str = None,
-        address_n: List[int] = None,
+        address_parameters: CardanoAddressParametersType = None,
         amount: int = None,
     ) -> None:
         self.address = address
-        self.address_n = address_n if address_n is not None else []
+        self.address_parameters = address_parameters
         self.amount = amount
 
     @classmethod
     def get_fields(cls) -> Dict:
         return {
             1: ('address', p.UnicodeType, 0),
-            2: ('address_n', p.UVarintType, p.FLAG_REPEATED),
+            2: ('address_parameters', CardanoAddressParametersType, 0),
             3: ('amount', p.UVarintType, 0),
         }

--- a/tests/device_tests/test_msg_cardano_get_address_slip39_basic.py
+++ b/tests/device_tests/test_msg_cardano_get_address_slip39_basic.py
@@ -16,6 +16,7 @@
 
 import pytest
 
+from trezorlib.cardano import create_address_parameters
 from trezorlib.messages import CardanoAddressType
 from trezorlib.cardano import get_address
 from trezorlib.tools import parse_path
@@ -51,6 +52,11 @@ def test_cardano_get_address(client, path, expected_address):
     client.use_passphrase("TREZOR")
 
     address = get_address(
-        client, parse_path(path), address_type=CardanoAddressType.BOOTSTRAP_ADDRESS
+        client,
+        address_parameters=create_address_parameters(
+            address_type=CardanoAddressType.BOOTSTRAP_ADDRESS,
+            address_n=parse_path(path),
+        ),
     )
+
     assert address == expected_address


### PR DESCRIPTION
Everything that has to do with transaction signing is done here except certificates, which are added in the next PR. I suggest going commit by commit, rather than looking at the whole PR at once - the commits shouldn't rewrite the work of previous commits.

I also had to refactor `address.py` a bit because I want the addresses returned as `bytes` not as human readable string when signing the transaction.