### PR TITLE
Cardano shelley update 2/3 - address as string updates

### DIFF
--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -116,7 +116,7 @@ message CardanoSignTx {
      * Structure representing cardano transaction output
      */
     message CardanoTxOutputType {
-        optional bytes address = 1;                                     // target coin address bytes hex encoded (not base58 or bech32)
+        optional string address = 1;                                    // target coin address in bech32 or base58
         optional uint64 amount = 3;                                     // amount to spend
         optional CardanoAddressParametersType address_parameters = 4;   // parameters used to derive the address
     }

--- a/core/src/apps/cardano/byron_address.py
+++ b/core/src/apps/cardano/byron_address.py
@@ -44,7 +44,7 @@ def derive_byron_address(
 
 def get_address_attributes(protocol_magic: int) -> dict:
     # protocol magic is included in Byron addresses only on testnets
-    if protocol_magic == protocol_magics.MAINNET:
+    if protocol_magics.is_mainnet(protocol_magic):
         address_attributes = {}
     else:
         address_attributes = {PROTOCOL_MAGIC_KEY: cbor.encode(protocol_magic)}
@@ -95,7 +95,7 @@ def _validate_address_data_protocol_magic(
         raise INVALID_ADDRESS
 
     attributes = address_data[1]
-    if protocol_magic == protocol_magics.MAINNET:
+    if protocol_magics.is_mainnet(protocol_magic):
         if PROTOCOL_MAGIC_KEY in attributes:
             raise NETWORK_MISMATCH
     else:  # testnet

--- a/core/src/apps/cardano/get_address.py
+++ b/core/src/apps/cardano/get_address.py
@@ -57,7 +57,7 @@ async def _display_address(
     await _show_staking_warnings(ctx, keychain, address_parameters)
 
     network = None
-    if protocol_magic != protocol_magics.MAINNET:
+    if not protocol_magics.is_mainnet(protocol_magic):
         network = protocol_magic
 
     while True:

--- a/core/src/apps/cardano/helpers/bech32.py
+++ b/core/src/apps/cardano/helpers/bech32.py
@@ -1,14 +1,18 @@
 from trezor.crypto import bech32
 
 
-"""
-Helper function to encode data longer than segwit addresses. We don't
-need the decode function. If it ever is needed trezor.crypto.bech32
-implementation needs to be updated for decoding longer strings than
-90 characters.
-"""
-
-
-def bech32_encode(human_readable_part: str, data: bytes) -> str:
+def encode(hrp: str, data: bytes) -> str:
     converted_bits = bech32.convertbits(data, 8, 5)
-    return bech32.bech32_encode(human_readable_part, converted_bits)
+    return bech32.bech32_encode(hrp, converted_bits)
+
+
+def decode(hrp: str, bech: str) -> bytes:
+    decoded_hrp, data = bech32.bech32_decode(bech, 130)
+    if decoded_hrp != hrp:
+        raise ValueError("Bech 32 decode failed")
+
+    decoded = bech32.convertbits(data, 5, 8, False)
+    if decoded is None:
+        raise ValueError("Bech 32 decode failed")
+
+    return bytes(decoded)

--- a/core/src/apps/cardano/helpers/bech32.py
+++ b/core/src/apps/cardano/helpers/bech32.py
@@ -1,9 +1,25 @@
 from trezor.crypto import bech32
 
+HRP_SEPARATOR = "1"
+
+HRP_ADDRESS = "addr"
+HRP_TESTNET_ADDRESS = "addr_test"
+HRP_REWARD_ADDRESS = "stake"
+HRP_TESTNET_REWARD_ADDRESS = "stake_test"
+
 
 def encode(hrp: str, data: bytes) -> str:
     converted_bits = bech32.convertbits(data, 8, 5)
     return bech32.bech32_encode(hrp, converted_bits)
+
+
+def decode_unsafe(bech: str) -> bytes:
+    hrp = get_hrp(bech)
+    return decode(hrp, bech)
+
+
+def get_hrp(bech: str):
+    return bech.split(HRP_SEPARATOR)[0]
 
 
 def decode(hrp: str, bech: str) -> bytes:

--- a/core/src/apps/cardano/helpers/network_ids.py
+++ b/core/src/apps/cardano/helpers/network_ids.py
@@ -1,2 +1,12 @@
 MAINNET = 1
 TESTNET = 0
+
+
+def is_mainnet(network_id: int) -> bool:
+    """
+    In the future there might be 15 mainnet IDs and
+    still only one testnet ID. Therefore it is safer
+    to check that it is not a testnet id. Also, if
+    the mainnet id was to change, this would still work.
+    """
+    return network_id != TESTNET

--- a/core/src/apps/cardano/helpers/protocol_magics.py
+++ b/core/src/apps/cardano/helpers/protocol_magics.py
@@ -7,5 +7,9 @@ NAMES = {
 }
 
 
+def is_mainnet(protocol_magic: int) -> bool:
+    return protocol_magic == MAINNET
+
+
 def to_ui_string(value: int) -> str:
     return NAMES.get(value, "Unknown")

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -14,7 +14,7 @@ from . import CURVE, seed
 from .address import (
     derive_address_bytes,
     derive_human_readable_address,
-    get_human_readable_address,
+    get_address_bytes,
     validate_full_path,
     validate_output_address,
 )
@@ -76,8 +76,8 @@ async def sign_tx(
 
 
 def _validate_network_info(network_id: int, protocol_magic: int) -> None:
-    is_mainnet_network_id = network_id == network_ids.MAINNET
-    is_mainnet_protocol_magic = protocol_magic == protocol_magics.MAINNET
+    is_mainnet_network_id = network_ids.is_mainnet(network_id)
+    is_mainnet_protocol_magic = protocol_magics.is_mainnet(protocol_magic)
 
     if is_mainnet_network_id != is_mainnet_protocol_magic:
         raise wire.ProcessError("Invalid network id/protocol magic combination!")
@@ -98,7 +98,7 @@ def _validate_outputs(
         if output.address_parameters:
             continue
         elif output.address is not None:
-            validate_output_address(bytes(output.address), protocol_magic, network_id)
+            validate_output_address(output.address, protocol_magic, network_id)
         else:
             raise wire.ProcessError(
                 "Each output must have an address field or address_parameters!"
@@ -153,7 +153,7 @@ def _build_outputs(
                 keychain, output.address_parameters, protocol_magic, network_id
             )
         else:
-            address = bytes(output.address)
+            address = get_address_bytes(output.address)
 
         result.append((address, amount))
 
@@ -255,7 +255,7 @@ async def _show_outputs(
             ):
                 continue
         else:
-            address = get_human_readable_address(bytes(output.address))
+            address = output.address
 
         total_amount += output.amount
 

--- a/core/src/trezor/crypto/bech32.py
+++ b/core/src/trezor/crypto/bech32.py
@@ -61,7 +61,9 @@ def bech32_encode(hrp: str, data: List[int]) -> str:
     return hrp + "1" + "".join([CHARSET[d] for d in combined])
 
 
-def bech32_decode(bech: str) -> Tuple[Optional[str], Optional[List[int]]]:
+def bech32_decode(
+    bech: str, max_bech_len: int = 90
+) -> Tuple[Optional[str], Optional[List[int]]]:
     """Validate a Bech32 string, and determine HRP and data."""
     if (any(ord(x) < 33 or ord(x) > 126 for x in bech)) or (
         bech.lower() != bech and bech.upper() != bech
@@ -69,7 +71,7 @@ def bech32_decode(bech: str) -> Tuple[Optional[str], Optional[List[int]]]:
         return (None, None)
     bech = bech.lower()
     pos = bech.rfind("1")
-    if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
+    if pos < 1 or pos + 7 > len(bech) or len(bech) > max_bech_len:
         return (None, None)
     if not all(x in CHARSET for x in bech[pos + 1 :]):
         return (None, None)

--- a/core/src/trezor/messages/CardanoTxOutputType.py
+++ b/core/src/trezor/messages/CardanoTxOutputType.py
@@ -16,7 +16,7 @@ class CardanoTxOutputType(p.MessageType):
 
     def __init__(
         self,
-        address: bytes = None,
+        address: str = None,
         amount: int = None,
         address_parameters: CardanoAddressParametersType = None,
     ) -> None:
@@ -27,7 +27,7 @@ class CardanoTxOutputType(p.MessageType):
     @classmethod
     def get_fields(cls) -> Dict:
         return {
-            1: ('address', p.BytesType, 0),
+            1: ('address', p.UnicodeType, 0),
             3: ('amount', p.UVarintType, 0),
             4: ('address_parameters', CardanoAddressParametersType, 0),
         }

--- a/core/tests/test_apps.cardano.address.py
+++ b/core/tests/test_apps.cardano.address.py
@@ -16,7 +16,7 @@ if not utils.BITCOIN_ONLY:
         _get_address_root,
         _address_hash,
     )
-    from apps.cardano.helpers import protocol_magics
+    from apps.cardano.helpers import network_ids, protocol_magics
     from apps.cardano.seed import Keychain
 
 
@@ -40,7 +40,7 @@ class TestCardanoAddress(unittest.TestCase):
                 address_type=CardanoAddressType.BYRON,
                 spending_key_path=[0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, 0x80000000 + i],
             )
-            address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, 0)
+            address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, network_ids.MAINNET)
             self.assertEqual(expected, address)
 
         nodes = [
@@ -89,7 +89,7 @@ class TestCardanoAddress(unittest.TestCase):
                 address_type=CardanoAddressType.BYRON,
                 spending_key_path=[0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, i],
             )
-            address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, 0)
+            address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, network_ids.MAINNET)
             self.assertEqual(address, expected)
 
         nodes = [
@@ -132,7 +132,7 @@ class TestCardanoAddress(unittest.TestCase):
             address_type=CardanoAddressType.BYRON,
             spending_key_path=[0x80000000 | 44, 0x80000000 | 1815],
         )
-        address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, 0)
+        address = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, network_ids.MAINNET)
         self.assertEqual(address, "Ae2tdPwUPEZ2FGHX3yCKPSbSgyuuTYgMxNq652zKopxT4TuWvEd8Utd92w3")
 
         priv, ext, pub, chain = (
@@ -242,7 +242,7 @@ class TestCardanoAddress(unittest.TestCase):
                 address_type=CardanoAddressType.BYRON,
                 spending_key_path=[0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, i],
             )
-            a = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, 0)
+            a = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, network_ids.MAINNET)
             n = keychain.derive([0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, i])
             self.assertEqual(a, address)
             self.assertEqual(hexlify(n.private_key()), priv)
@@ -309,7 +309,7 @@ class TestCardanoAddress(unittest.TestCase):
                 address_type=CardanoAddressType.BYRON,
                 spending_key_path=[0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, i],
             )
-            a = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, 0)
+            a = derive_human_readable_address(keychain, address_parameters, protocol_magics.MAINNET, network_ids.MAINNET)
             n = keychain.derive([0x80000000 | 44, 0x80000000 | 1815, 0x80000000, 0, i])
             self.assertEqual(a, address)
             self.assertEqual(hexlify(n.private_key()), priv)
@@ -325,12 +325,9 @@ class TestCardanoAddress(unittest.TestCase):
 
         test_vectors = [
             # network id, account, expected result
-            # data from shelley test vectors
-            (0, 0, "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r"),
-            (3, 0, "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd"),
             # data generated with code under test
-            (0, 4, "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsuzz8x7"),
-            (3, 4, "addr1q04sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsx3ewes"),
+            (network_ids.MAINNET, 4, "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r"),
+            (network_ids.TESTNET, 4, "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlswzkqcu"),
         ]
 
         for network_id, account, expected_address in test_vectors:
@@ -352,16 +349,13 @@ class TestCardanoAddress(unittest.TestCase):
         test_vectors = [
             # network id, account, staking key hash, expected result
             # own staking key hash
-            # data from shelley test vectors
-            (0, 0, unhexlify("32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc"), "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r"),
-            (3, 0, unhexlify("32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc"), "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd"),
             # data generated with code under test
-            (0, 4, unhexlify("1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff"), "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsuzz8x7"),
-            (3, 4, unhexlify("1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff"), "addr1q04sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsx3ewes"),
+            (network_ids.MAINNET, 4, unhexlify("1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff"), "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r"),
+            (network_ids.TESTNET, 4, unhexlify("1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff"), "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlswzkqcu"),
             # staking key hash not owned - derived with "all all..." mnenomnic, data generated with code under test
-            (0, 4, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsh42t2h"),
-            (3, 0, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzersj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms3rqaac"),
-            (3, 4, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr1q04sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsdx3z4e"),
+            (network_ids.MAINNET, 4, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsxrrvc2"),
+            (network_ids.MAINNET, 0, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzersj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms6xjnst"),
+            (network_ids.TESTNET, 4, unhexlify("122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277"), "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms947v54"),
         ]
 
         for network_id, account, staking_key_hash, expected_address in test_vectors:
@@ -408,8 +402,8 @@ class TestCardanoAddress(unittest.TestCase):
 
         test_vectors = [
             # network id, expected result
-            (0, "addr1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6g8jlq"),
-            (3, "addr1vw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6h7glf")
+            (network_ids.MAINNET, "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8"),
+            (network_ids.TESTNET, "addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz")
         ]
 
         for network_id, expected_address in test_vectors:
@@ -429,8 +423,8 @@ class TestCardanoAddress(unittest.TestCase):
 
         test_vectors = [
             # network id, pointer, expected result
-            (0, CardanoBlockchainPointerType(1, 2, 3), "addr1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpslhplej"),
-            (3, CardanoBlockchainPointerType(24157, 177, 42), "addr1gw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2x4v58t")
+            (network_ids.MAINNET, CardanoBlockchainPointerType(1, 2, 3), "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpse33frd"),
+            (network_ids.TESTNET, CardanoBlockchainPointerType(24157, 177, 42), "addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2pfz4ly")
         ]
 
         for network_id, pointer, expected_address in test_vectors:
@@ -493,8 +487,8 @@ class TestCardanoAddress(unittest.TestCase):
 
         test_vectors = [
             # network id, expected result
-            (0, "addr1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqq8lpzh"),
-            (3, "addr1uvevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqqcxmz7")
+            (network_ids.MAINNET, "stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz"),
+            (network_ids.TESTNET, "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl")
         ]
 
         for network_id, expected_address in test_vectors:

--- a/core/tests/test_apps.cardano.bech32.py
+++ b/core/tests/test_apps.cardano.bech32.py
@@ -1,45 +1,26 @@
-from ubinascii import unhexlify
-
 from common import *
 
-from apps.cardano.helpers.bech32 import bech32_encode
-
+from apps.cardano.helpers import bech32
 
 @unittest.skipUnless(not utils.BITCOIN_ONLY, "altcoin")
 class TestCardanoBech32(unittest.TestCase):
     def test_decode_and_encode(self):
         expected_bechs = [
-            # human readable part, data, expected bech32
-            ("a", "", "a12uel5l"),
-            (
-                "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
-                "",
-                "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
-            ),
-            (
-                "abcdef",
-                "00443214c74254b635cf84653a56d7c675be77df",
-                "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
-            ),
-            (
-                "1",
-                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
-            ),
-            (
-                "split",
-                "c5f38b70305f519bf66d85fb6cf03058f3dde463ecd7918f2dc743918f2d",
-                "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
-            ),
-            (
-                "addr",
-                "0080f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
-                "addr1qzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92sj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsw8ezsk",
-            ),
+            # human readable part, bech32
+            ("a", "a12uel5l"),
+            ("an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio",
+                "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs"),
+            ("abcdef", "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw"),
+            ("1", "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j"),
+            ("split", "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w"),
+            ("addr", "addr1qzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92sj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsw8ezsk"),
+            ("addr_test", "addr_test1qzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92sj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsu8d9w5")
         ]
 
-        for human_readable_part, data, expected_bech in expected_bechs:
-            actual_bech = bech32_encode(human_readable_part, unhexlify(data))
+        for expected_human_readable_part, expected_bech in expected_bechs:
+            decoded = bech32.decode(expected_human_readable_part, expected_bech)
+            actual_bech = bech32.encode(expected_human_readable_part, decoded)
+
             self.assertEqual(actual_bech, expected_bech)
 
 

--- a/python/src/trezorlib/cardano.py
+++ b/python/src/trezorlib/cardano.py
@@ -112,7 +112,7 @@ def create_output(output) -> messages.CardanoTxOutputType:
 
     if contains_address:
         return messages.CardanoTxOutputType(
-            address=bytes.fromhex(output["address"]), amount=int(output["amount"])
+            address=output["address"], amount=int(output["amount"])
         )
     else:
         return _create_change_output(output)

--- a/python/src/trezorlib/messages/CardanoTxOutputType.py
+++ b/python/src/trezorlib/messages/CardanoTxOutputType.py
@@ -16,7 +16,7 @@ class CardanoTxOutputType(p.MessageType):
 
     def __init__(
         self,
-        address: bytes = None,
+        address: str = None,
         amount: int = None,
         address_parameters: CardanoAddressParametersType = None,
     ) -> None:
@@ -27,7 +27,7 @@ class CardanoTxOutputType(p.MessageType):
     @classmethod
     def get_fields(cls) -> Dict:
         return {
-            1: ('address', p.BytesType, 0),
+            1: ('address', p.UnicodeType, 0),
             3: ('amount', p.UVarintType, 0),
             4: ('address_parameters', CardanoAddressParametersType, 0),
         }

--- a/tests/device_tests/test_msg_cardano_get_address.py
+++ b/tests/device_tests/test_msg_cardano_get_address.py
@@ -91,19 +91,6 @@ def test_cardano_get_address(client, spending_path, protocol_magic, expected_add
 @pytest.mark.parametrize(
     "spending_path, staking_path, network_id, expected_address",
     [
-        # data form shelley test vectors
-        (
-            "m/1852'/1815'/0'/0/0",
-            "m/1852'/1815'/0'/2/0",
-            0,
-            "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r",
-        ),
-        (
-            "m/1852'/1815'/0'/0/0",
-            "m/1852'/1815'/0'/2/0",
-            3,
-            "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd",
-        ),
         # data generated with code under test
         (
             "m/1852'/1815'/4'/0/0",
@@ -115,7 +102,7 @@ def test_cardano_get_address(client, spending_path, protocol_magic, expected_add
             "m/1852'/1815'/4'/0/0",
             "m/1852'/1815'/4'/2/0",
             NETWORK_IDS["testnet"],
-            "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsuzz8x7",
+            "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlswzkqcu",
         ),
     ],
 )
@@ -142,19 +129,6 @@ def test_cardano_get_base_address(
 @pytest.mark.parametrize(
     "spending_path, staking_key_hash, network_id, expected_address",
     [
-        # data from shelley test vectors
-        (
-            "m/1852'/1815'/0'/0/0",
-            "32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc",
-            0,
-            "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqcyl47r",
-        ),
-        (
-            "m/1852'/1815'/0'/0/0",
-            "32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc",
-            3,
-            "addr1qw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwqzhyupd",
-        ),
         # data generated with code under test
         (
             "m/1852'/1815'/4'/0/0",
@@ -166,7 +140,7 @@ def test_cardano_get_base_address(
             "m/1852'/1815'/4'/0/0",
             "1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff",
             NETWORK_IDS["testnet"],
-            "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsuzz8x7",
+            "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlswzkqcu",
         ),
         # staking key hash not owned - derived with "all all..." mnenomnic, data generated with code under test
         (
@@ -179,13 +153,13 @@ def test_cardano_get_base_address(
             "m/1852'/1815'/0'/0/0",
             "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
             NETWORK_IDS["testnet"],
-            "addr1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzersj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmstsm5zk",
+            "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzersj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmses0nu5",
         ),
         (
             "m/1852'/1815'/4'/0/0",
             "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
             NETWORK_IDS["testnet"],
-            "addr1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsh42t2h",
+            "addr_test1qr4sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfms947v54",
         ),
     ],
 )
@@ -213,16 +187,16 @@ def test_cardano_get_base_address_with_staking_key_hash(
 @pytest.mark.parametrize(
     "spending_path, network_id, expected_address",
     [
-        # data form shelley test vectors
+        # data generated with code under test
         (
             "m/1852'/1815'/0'/0/0",
-            0,
-            "addr1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6g8jlq",
+            NETWORK_IDS["mainnet"],
+            "addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
         ),
         (
             "m/1852'/1815'/0'/0/0",
-            3,
-            "addr1vw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers6h7glf",
+            NETWORK_IDS["testnet"],
+            "addr_test1vz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspjrlsz",
         ),
     ],
 )
@@ -248,22 +222,22 @@ def test_cardano_get_enterprise_address(
 @pytest.mark.parametrize(
     "spending_path, block_index, tx_index, certificate_index, network_id, expected_address",
     [
-        # data form shelley test vectors
+        # data generated with code under test
         (
             "m/1852'/1815'/0'/0/0",
             1,
             2,
             3,
-            0,
-            "addr1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpslhplej",
+            NETWORK_IDS["mainnet"],
+            "addr1gx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzerspqgpse33frd",
         ),
         (
             "m/1852'/1815'/0'/0/0",
             24157,
             177,
             42,
-            3,
-            "addr1gw2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2x4v58t",
+            NETWORK_IDS["testnet"],
+            "addr_test1gz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer5ph3wczvf2pfz4ly",
         ),
     ],
 )
@@ -298,16 +272,16 @@ def test_cardano_get_pointer_address(
 @pytest.mark.parametrize(
     "spending_path, network_id, expected_address",
     [
-        # data generated by code under test
+        # data generated with code under test
         (
             "m/1852'/1815'/0'/2/0",
             NETWORK_IDS["mainnet"],
-            "addr1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqq40szs",
+            "stake1uyevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqxdekzz",
         ),
         (
             "m/1852'/1815'/0'/2/0",
             NETWORK_IDS["testnet"],
-            "addr1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqq8lpzh",
+            "stake_test1uqevw2xnsc0pvn9t9r9c7qryfqfeerchgrlm3ea2nefr9hqp8n5xl",
         ),
     ],
 )

--- a/tests/device_tests/test_msg_cardano_sign_transaction.py
+++ b/tests/device_tests/test_msg_cardano_sign_transaction.py
@@ -435,7 +435,7 @@ INVALID_VECTORS = [
         # ttl
         10,
         # error message
-        "Output address network mismatch!",
+        "Invalid address",
     ),
     # Shelley testnet transaction with mainnet output
     (
@@ -452,7 +452,7 @@ INVALID_VECTORS = [
         # ttl
         10,
         # error message
-        "Output address network mismatch!",
+        "Invalid address",
     ),
     # Testnet protocol magic with mainnet network id
     (

--- a/tests/device_tests/test_msg_cardano_sign_transaction.py
+++ b/tests/device_tests/test_msg_cardano_sign_transaction.py
@@ -47,7 +47,7 @@ SAMPLE_INPUTS = {
 
 SAMPLE_OUTPUTS = {
     "simple_byron_output": {
-        "address": "82d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c2561",
+        "address": "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
         "amount": "3003112",
     },
     "byron_change_output": {
@@ -56,7 +56,7 @@ SAMPLE_OUTPUTS = {
         "amount": "1000000",
     },
     "simple_shelley_output": {
-        "address": "017cb05fce110fb999f01abb4f62bc455e217d4a51fde909fa9aea545443ac53c046cf6a42095e3c60310fa802771d0672f8fe2d1861138b09da61d425f3461114",
+        "address": "addr1q97tqh7wzy8mnx0sr2a57c4ug40zzl222877jz06nt49g4zr43fuq3k0dfpqjh3uvqcsl2qzwuwsvuhclck3scgn3vya5cw5yhe5vyg5x20akz",
         "amount": "1",
     },
     "base_address_change_output": {
@@ -85,27 +85,27 @@ SAMPLE_OUTPUTS = {
         "amount": "7120787",
     },
     "invalid_address": {
-        "address": "83d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c256100",
+        "address": "jsK75PTH2esX8k4Wvxenyz83LJJWToBbVmGrWUer2CHFHanLseh7r3sW5X5q",
         "amount": "3003112",
     },
     "invalid_cbor": {
-        "address": "8282d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c2561158282d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c2561",
+        "address": "5dnY6xgRcNUSLGa4gfqef2jGAMHb7koQs9EXErXLNC1LiMPUnhn8joXhvEJpWQtN3F4ysATcBvCn5tABgL3e4hPWapPHmcK5GJMSEaET5JafgAGwSrznzL1Mqa",
         "amount": "3003112",
     },
     "invalid_crc": {
-        "address": "82d818582183581c578e965bd8e000b67ae6847de0c098b5c63470dc1a51222829c482bfa0001a00000000",
+        "address": "Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRZR3Mbm",
         "amount": "3003112",
     },
     "large_simple_byron_output": {
-        "address": "82d818582183581c9e1c71de652ec8b85fec296f0685ca3988781c94a2e1a5d89d92f45fa0001a0d0c2561",
+        "address": "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
         "amount": "449999999199999999",
     },
     "testnet_output": {
-        "address": "82d818582583581cc817d85b524e3d073795819a25cdbb84cff6aa2bbb3a081980d248cba10242182a001a0fb6fc61",
+        "address": "2657WMsDfac7BteXkJq5Jzdog4h47fPbkwUM49isuWbYAr2cFRHa3rURP236h9PBe",
         "amount": "3003112",
     },
     "shelley_testnet_output": {
-        "address": "60a6274badf4c9ca583df893a73139625ff4dc73aaa3082e67d6d5d08e0ce3daa4",
+        "address": "addr_test1vznzwjad7nyu5kpalzf6wvfevf0lfhrn423sstn86m2aprsvu0d2gxeef9a",
         "amount": "1",
     },
 }


### PR DESCRIPTION
I've drafted the update to strings. It's not yet 100% done:
- address tests need to be updated with bech prefixes/correct network ids
- reward addresses are still returned with `addr`/`addr_test` prefix
- some refactoring is still needed
 
I'd like it to be internally reviewed first.