### PR TITLE
Change address UI to accomodate longer account/address numbers

### DIFF
--- a/common/tests/fixtures/cardano/get_address_byron.json
+++ b/common/tests/fixtures/cardano/get_address_byron.json
@@ -42,7 +42,7 @@
         "path": "m/44'/1815'/0'/0/0",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac5F3zbgs9BwNWx3dhGAJERkAL93gPa68NJ2i8mbCHm2pLUHWSj8Mfea"
@@ -53,7 +53,7 @@
         "path": "m/44'/1815'/0'/0/1",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac6ezKWszxLFqJjSUgpg9NgxKc1koqi24sVpRaPhiwMaExk4useKn5HA"
@@ -64,7 +64,7 @@
         "path": "m/44'/1815'/0'/0/2",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result":  {
         "expected_address": "2657WMsDfac7hr1ioJGr6g7r6JRx4r1My8Rj91tcPTeVjJDpfBYKURrPG2zVLx2Sq"

--- a/common/tests/fixtures/cardano/get_address_byron.slip39.json
+++ b/common/tests/fixtures/cardano/get_address_byron.slip39.json
@@ -46,7 +46,7 @@
         "path": "m/44'/1815'/0'/0/0",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac7SH1rhA2PWBggGAPrKyLt1r9SL9gajPxxcH15ZxuCUb4aK9mQ9w7dU"
@@ -57,7 +57,7 @@
         "path": "m/44'/1815'/0'/0/1",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac6Cmfg4Varph2qyLKGi2K9E8jrtvjHVzfSjmbTMGy5sY3HpxCKsmtDA"
@@ -68,7 +68,7 @@
         "path": "m/44'/1815'/0'/0/2",
         "address_type": "byron",
         "protocol_magic": 42,
-        "network_id": 1
+        "network_id": 0
       },
       "result": {
         "expected_address": "2657WMsDfac5ANb5Mw6Rbgdz6nvs2Tu675vGbbVSzXQbAkQuMWtqBvEeKTrHNtXY7"

--- a/common/tests/fixtures/cardano/get_base_address.json
+++ b/common/tests/fixtures/cardano/get_base_address.json
@@ -22,7 +22,7 @@
         "address_type": "base",
         "staking_path": "m/1852'/1815'/4'/2/0",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqnsc9fs"

--- a/common/tests/fixtures/cardano/get_base_address_with_staking_key_hash.json
+++ b/common/tests/fixtures/cardano/get_base_address_with_staking_key_hash.json
@@ -22,7 +22,7 @@
         "address_type": "base",
         "staking_key_hash": "1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf"
@@ -46,7 +46,7 @@
         "address_type": "base",
         "staking_key_hash": "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92sj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsu8d9w5"
@@ -58,7 +58,7 @@
         "address_type": "base",
         "staking_key_hash": "122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsj922xhxkn6twlq2wn4q50q352annk3903tj00h45mgfmsvvdk2q"

--- a/common/tests/fixtures/cardano/get_enterprise_address.json
+++ b/common/tests/fixtures/cardano/get_enterprise_address.json
@@ -22,7 +22,7 @@
         "address_type": "enterprise",
         "staking_key_hash": "1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47"

--- a/common/tests/fixtures/cardano/get_pointer_address.json
+++ b/common/tests/fixtures/cardano/get_pointer_address.json
@@ -26,7 +26,7 @@
         "tx_index": 177,
         "certificate_index": 42,
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "addr_test1gzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925ph3wczvf2ag2x9t"

--- a/common/tests/fixtures/cardano/get_reward_address.json
+++ b/common/tests/fixtures/cardano/get_reward_address.json
@@ -20,7 +20,7 @@
         "path": "m/1852'/1815'/0'/2/0",
         "address_type": "reward",
         "network_id": 0,
-        "protocol_magic": 764824073
+        "protocol_magic": 42
       },
       "result": {
         "expected_address": "stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq"

--- a/core/src/apps/cardano/get_address.py
+++ b/core/src/apps/cardano/get_address.py
@@ -13,6 +13,7 @@ from .layout import (
     show_warning_address_foreign_staking_key,
     show_warning_address_pointer,
 )
+from .sign_tx import validate_network_info
 
 if False:
     from trezor.messages import CardanoAddressParametersType, CardanoGetAddress
@@ -27,6 +28,8 @@ async def get_address(
     await paths.validate_path(
         ctx, validate_full_path, keychain, address_parameters.address_n, CURVE
     )
+
+    validate_network_info(msg.network_id, msg.protocol_magic)
 
     try:
         address = derive_human_readable_address(
@@ -54,9 +57,9 @@ async def _display_address(
 ) -> None:
     await _show_staking_warnings(ctx, keychain, address_parameters)
 
-    network = None
+    network_name = None
     if not protocol_magics.is_mainnet(protocol_magic):
-        network = protocol_magic
+        network_name = protocol_magics.to_ui_string(protocol_magic)
 
     while True:
         if await show_address(
@@ -64,7 +67,7 @@ async def _display_address(
             address,
             address_parameters.address_type,
             address_parameters.address_n,
-            network=network,
+            network=network_name,
         ):
             break
         if await show_qr(

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -193,7 +193,7 @@ async def show_address(
     address: str,
     address_type: EnumTypeCardanoAddressType,
     path: List[int],
-    network: int = None,
+    network: str = None,
 ) -> bool:
     """
     Custom show_address function is needed because cardano addresses don't
@@ -204,28 +204,28 @@ async def show_address(
     t1 = Text(address_type_label, ui.ICON_RECEIVE, ui.GREEN)
 
     lines_per_page = 5
-    first_page_lines_used = 0
+    lines_used_on_first_page = 0
 
     # assemble first page to be displayed (path + network + whatever part of the address fits)
     if network is not None:
-        t1.normal("%s network" % protocol_magics.to_ui_string(network))
-        first_page_lines_used += 1
+        t1.normal("%s network" % network)
+        lines_used_on_first_page += 1
 
     path_str = address_n_to_str(path)
     t1.mono(path_str)
-    first_page_lines_used = min(
-        first_page_lines_used + math.ceil(len(path_str) / _MAX_MONO_LINE),
+    lines_used_on_first_page = min(
+        lines_used_on_first_page + math.ceil(len(path_str) / _MAX_MONO_LINE),
         lines_per_page,
     )
 
     address_lines = list(chunks(address, 17))
-    for address_line in address_lines[: lines_per_page - first_page_lines_used]:
+    for address_line in address_lines[: lines_per_page - lines_used_on_first_page]:
         t1.bold(address_line)
 
     # append remaining pages containing the rest of the address
     pages = [t1] + _paginate_lines(
         address_lines,
-        lines_per_page - first_page_lines_used,
+        lines_per_page - lines_used_on_first_page,
         address_type_label,
         ui.ICON_RECEIVE,
         lines_per_page,

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -72,7 +72,7 @@ async def sign_tx(
         if msg.fee > LOVELACE_MAX_SUPPLY:
             raise wire.ProcessError("Fee is out of range!")
 
-        _validate_network_info(msg.network_id, msg.protocol_magic)
+        validate_network_info(msg.network_id, msg.protocol_magic)
 
         for i in msg.inputs:
             await validate_path(ctx, validate_full_path, keychain, i.address_n, CURVE)
@@ -97,7 +97,7 @@ async def sign_tx(
     return tx
 
 
-def _validate_network_info(network_id: int, protocol_magic: int) -> None:
+def validate_network_info(network_id: int, protocol_magic: int) -> None:
     """
     We are only concerned about checking that both network_id and protocol_magic
     belong to the mainnet or that both belong to a testnet. We don't need to check for


### PR DESCRIPTION
With the newest staking update, users are expected to split funds into bip44 accounts if they want to delegate funds to multiple stake pools. This creates issue with the UI however, since currently we are hitting the character limit. We explored 3 options for fixing this, and in the end decided to implement option 1 which is this PR. The UI got future proofed for any legal paths, not just ones currently valid (so it works properly even for accounts over 20' and addresses over 1000000)
![option 1](https://user-images.githubusercontent.com/9059268/93596780-40865480-f9ba-11ea-9871-932b7ce02e16.png)
![option 2](https://user-images.githubusercontent.com/9059268/93596788-42e8ae80-f9ba-11ea-9268-babdbc7b02d2.png)
![option 3](https://user-images.githubusercontent.com/9059268/93596791-43814500-f9ba-11ea-93e9-df7751829c17.png)


