### PR TITLE
WIP unify cardano path validaiton

### DIFF
--- a/core/src/apps/cardano/get_address.py
+++ b/core/src/apps/cardano/get_address.py
@@ -30,7 +30,6 @@ async def get_address(
         ctx,
         keychain,
         address_parameters.address_n,
-        # path must match the ADDRESS schema
         SCHEMA_ADDRESS.match(address_parameters.address_n),
     )
 

--- a/core/src/apps/cardano/helpers/__init__.py
+++ b/core/src/apps/cardano/helpers/__init__.py
@@ -1,5 +1,6 @@
 from trezor import wire
 
+INVALID_DERIVATION_PATH = wire.ProcessError("Invalid derivation path")
 INVALID_ADDRESS = wire.ProcessError("Invalid address")
 NETWORK_MISMATCH = wire.ProcessError("Output address network mismatch!")
 INVALID_CERTIFICATE = wire.ProcessError("Invalid certificate")
@@ -11,5 +12,8 @@ INVALID_STAKE_POOL_REGISTRATION_TX_STRUCTURE = wire.ProcessError(
 INVALID_STAKEPOOL_REGISTRATION_TX_INPUTS = wire.ProcessError(
     "Stakepool registration transaction can contain only external inputs"
 )
+INVALID_SHELLEY_ADDRESS_PATH = wire.ProcessError("Invalid path for shelley address!")
+INVALID_BYRON_ADDRESS_PATH = wire.ProcessError("Invalid path for byron address!")
+
 
 LOVELACE_MAX_SUPPLY = 45_000_000_000 * 1_000_000

--- a/core/src/apps/cardano/helpers/paths.py
+++ b/core/src/apps/cardano/helpers/paths.py
@@ -10,5 +10,8 @@ SHELLEY_ROOT = [1852 | HARDENED, SLIP44_ID | HARDENED]
 SCHEMA_PUBKEY = PathSchema("m/[44,1852]'/coin_type'/account'/*", SLIP44_ID)
 SCHEMA_ADDRESS = PathSchema("m/[44,1852]'/coin_type'/account'/[0,1,2]/address_index", SLIP44_ID)
 # staking is only allowed on Shelley paths with suffix /2/0
-SCHEMA_STAKING = PathSchema("m/1852'/coin_type'/account'/2/0", SLIP44_ID)
+SCHEMA_STAKING = PathSchema(f"m/1852'/coin_type'/account'/2/0", SLIP44_ID)
+SCHEMA_SPENDING = PathSchema(f"m/[44,1852]'/coin_type'/account'/[0,1]/address_index", SLIP44_ID)
+SCHEMA_SHELLEY = PathSchema(f"m/1852'/coin_type'/account'/[0,1,2]/address_index", SLIP44_ID)
+SCHEMA_BYRON = PathSchema(f"m/44'/coin_type'/account'/[0,1]/address_index", SLIP44_ID)
 # fmt: on


### PR DESCRIPTION
Motivation: There is an inconsitency between staking and spending path validation. The logic to validate staking paths to certificates and withdrawals forced them to have max account number 100 whereas spending paths were unbounded and triggered only a warning beyond 100. This is a WIP to unify the account index validation and make the validation of staking/spending paths stronger overall