### PR TITLE
Check safety_checks setting before showing warnings

### DIFF
--- a/core/src/apps/cardano/helpers/staking_use_cases.py
+++ b/core/src/apps/cardano/helpers/staking_use_cases.py
@@ -2,7 +2,6 @@ from trezor.messages import CardanoAddressType
 
 from ..address import get_public_key_hash
 from ..seed import is_shelley_path
-from .paths import SCHEMA_ADDRESS_ANY_ACCOUNT
 from .utils import to_account_path
 
 if False:
@@ -29,8 +28,6 @@ def get(
 ) -> int:
     address_type = address_parameters.address_type
     if address_type == CardanoAddressType.BASE:
-        if not SCHEMA_ADDRESS_ANY_ACCOUNT.match(address_parameters.address_n):
-            return MISMATCH
         if not is_shelley_path(address_parameters.address_n):
             return MISMATCH
 

--- a/core/src/apps/cardano/helpers/utils.py
+++ b/core/src/apps/cardano/helpers/utils.py
@@ -1,5 +1,9 @@
 from micropython import const
 
+from trezor import wire
+
+from apps.common import safety_checks
+
 if False:
     from typing import List
 
@@ -29,3 +33,8 @@ def variable_length_encode(number: int) -> bytes:
 def to_account_path(path: List[int]) -> List[int]:
     ACCOUNT_PATH_LENGTH = const(3)
     return path[:ACCOUNT_PATH_LENGTH]
+
+
+def fail_if_strict(msg):
+    if safety_checks.is_strict():
+        raise wire.DataError(msg)


### PR DESCRIPTION
IMHO the various staking warnings seem to me like a legit use case even for non-advanced users, so I didn't wrap those in `fail_if_strict`.