### PR TITLE
fix(core/Cardano): do not show change output in byron-shelley transfers

### DIFF
--- a/common/tests/fixtures/cardano/sign_tx.json
+++ b/common/tests/fixtures/cardano/sign_tx.json
@@ -681,6 +681,46 @@
         "tx_hash": "b621e22f7cb9aac1a70a3362fde88bdfd31fc100e20f3f3c24a7b853536b4f50",
         "serialized_tx": "83a300818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b70001818258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1584088c35c125664935117d9aa1173cae5f01967b02f6b716b1a135570b2fee74728f2f3e39d56b748302c36e2407d7bfefc4054ca1e60dd857e461734ae41d00500f6"
       }
+    },
+    {
+      "description": "Byron to Shelley transfer",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "certificates": [],
+        "withdrawals": [],
+        "metadata": "",
+        "input_flow": [["YES"], ["YES"]],
+        "inputs": [
+          {
+            "path": "m/44'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          },
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 1
+          }
+        ],
+        "outputs": [
+          {
+            "address": "addr1z90z7zqwhya6mpk5q929ur897g3pp9kkgalpreny8y304r2dcrtx0sf3dluyu4erzr3xtmdnzvcyfzekkuteu2xagx0qeva0pr",
+            "amount": "1"
+          },
+          {
+            "addressType": 0,
+            "path": "m/1852'/1815'/0'/0/0",
+            "stakingPath": "m/1852'/1815'/0'/2/0",
+            "amount": "7120787"
+          }
+        ]
+      },
+      "result": {
+        "tx_hash": "00d393f7fc9a8c17b3efccb44dad9d7e15fdaf2d942a3a455b52b5be016066dd",
+        "serialized_tx": "83a300828258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7008258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7010182825839115e2f080eb93bad86d401545e0ce5f2221096d6477e11e6643922fa8d4dc0d667c1316ff84e572310e265edb31330448b36b7179e28dd419e018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182aa200818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c158408393ba106a791a55ea588a124f539a02e149cc259df703ccc29f12f2ddc2734e6a07e37d645b4d0c9cc633493cb99ed7a0057b046dc18113685a1ae6d36686080281845820b90fb812a2268e9569ff1172e8daed1da3dc7e72c7bded7c5bcb7282039f90d558407782cdec14dcc5f506bb17275988771fce6ab4b744774d562c7aa120a008a9b9c28220b39382fbc8b70ef3d8a2fb2ba6aa55d732eaea1a3c71e568b387f5f40c5820fd8e71c1543de2cdc7f7623130c5f2cceb53549055fa1f5bc88199989e08cce741a0f6"
+      }
     }
   ]
 }

--- a/core/src/apps/cardano/sign_tx.py
+++ b/core/src/apps/cardano/sign_tx.py
@@ -670,7 +670,7 @@ def _should_hide_output(output: List[int], inputs: List[CardanoTxInputType]) -> 
         inp = tx_input.address_n
         if (
             len(output) != BIP_PATH_LENGTH
-            or output[: (ACCOUNT_PATH_INDEX + 1)] != inp[: (ACCOUNT_PATH_INDEX + 1)]
+            or output[ACCOUNT_PATH_INDEX] != inp[ACCOUNT_PATH_INDEX]
             or output[-2] >= 2
             or output[-1] >= MAX_CHANGE_ADDRESS_INDEX
         ):

--- a/tests/ui_tests/fixtures.json
+++ b/tests/ui_tests/fixtures.json
@@ -1,4 +1,5 @@
 {
+"cardano-test_sign_tx.py::test_cardano_sign_tx[byron_to_shelley_transfer]": "f0e91af34e0be910cafbb885305bd553470a69ec50c2f2dae1afd2374fe5947a",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_change0]": "5e2334cff9d0946ec722d69d7065023d707d8208a0ceee928824fd006edb93ad",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_change1]": "1ac78675dd64f4acbf7cf8f24bc1492bec5f0bce32a3f860742d5fa1922afb24",
 "cardano-test_sign_tx.py::test_cardano_sign_tx[mainnet_transaction_with_multiple_inputs]": "8151b1b3cfa5ef79a256409d78b0219eb43b8fb498776b16e2f43bb5c9a38c55",


### PR DESCRIPTION
Motivation: tsusanka noticed that Trezor shows the base address change output if some of the inputs happens to be a Byron era input. This is the result of the current `_should_hide_output()` logic which hides outputs only if their path matches with all the inputs up to the account index.

Changes: relax the `_should_hide_output()` logic to look only at the account indices when matching the tx output with the inputs.

Testing:
* added testcase with a tx with a` byron input and shelley output which fails with the previous logic as one more screen appeared, requiring a different input flow
* `pytest tests/device_tests -k "test_cardano_sign_tx"` passes