### PR TITLE
feat(cardano): add support for collateral inputs

### DIFF
--- a/common/protob/messages-cardano.proto
+++ b/common/protob/messages-cardano.proto
@@ -144,6 +144,7 @@ message CardanoSignTxInit {
     optional uint64 validity_interval_start = 11;
     required uint32 witness_requests_count = 12;
     optional bytes script_data_hash = 13;
+    required uint32 collateral_inputs_count = 14;
 }
 
 /**

--- a/common/tests/fixtures/cardano/sign_tx.failed.json
+++ b/common/tests/fixtures/cardano/sign_tx.failed.json
@@ -15,6 +15,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -45,6 +46,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -75,6 +77,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -105,6 +108,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -135,6 +139,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -165,6 +170,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -195,6 +201,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -230,6 +237,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -260,6 +268,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -290,6 +299,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -320,6 +330,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -350,6 +361,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -380,6 +392,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -410,6 +423,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -440,6 +454,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -478,6 +493,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -514,6 +530,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -549,6 +566,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -584,6 +602,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -623,6 +642,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -655,6 +675,7 @@
           "hash": "a200a11864a118c843aa00ff01"
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -695,6 +716,7 @@
           }
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -737,6 +759,7 @@
           }
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -767,6 +790,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f",
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -797,6 +821,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/190'/0/0",
@@ -833,6 +858,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -874,6 +900,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/190'/0/0",
@@ -904,6 +931,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -949,6 +977,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -999,6 +1028,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1040,6 +1070,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1075,6 +1106,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1110,6 +1142,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1151,6 +1184,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1197,6 +1231,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1226,6 +1261,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/0",
@@ -1260,6 +1296,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/0",

--- a/common/tests/fixtures/cardano/sign_tx.json
+++ b/common/tests/fixtures/cardano/sign_tx.json
@@ -15,6 +15,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -53,6 +54,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -96,6 +98,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -140,6 +143,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -211,6 +215,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -256,6 +261,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/190'/0/0",
@@ -301,6 +307,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -345,6 +352,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -389,6 +397,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -435,6 +444,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -483,6 +493,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -526,6 +537,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -569,6 +581,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -618,6 +631,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -672,6 +686,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -722,6 +737,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/190'/0/0",
@@ -768,6 +784,7 @@
           "hash": "ea4c91860dd5ec5449f8f985d227946ff39086b17f10b5afb93d12ee87050b6a"
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -817,6 +834,7 @@
           }
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -860,6 +878,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02",
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -888,6 +907,51 @@
       }
     },
     {
+      "description": "transaction with collateral",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "ttl": 10,
+        "certificates": [],
+        "withdrawals": [],
+        "auxiliary_data": null,
+        "script_data_hash": null,
+        "collateral_inputs": [
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          }
+        ],
+        "inputs": [
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          }
+        ],
+        "outputs": [
+          {
+            "address": "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r",
+            "amount": "1"
+          }
+        ],
+        "signing_mode": "ORDINARY_TRANSACTION"
+      },
+      "result": {
+        "tx_hash": "97b8e65e8e34dec8c22f311736ec0c3d25d2dcf61de06e7f2864bc7a0322ee68",
+        "witnesses": [
+          {
+            "type": 1,
+            "pub_key": "5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1",
+            "signature": "639378d825f9fadf37fa69af912315103d1fbce6dc49bf246cd65a4b43f9106a133fcd8ce7a449c902c4d7114b87c08d2586749241796920edc06e12b96f4e02",
+            "chain_code": null
+          }
+        ]
+      }
+    },
+    {
       "description": "Testnet transaction",
       "parameters": {
         "protocol_magic": 42,
@@ -898,6 +962,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -946,6 +1011,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1002,6 +1068,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1069,6 +1136,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1108,6 +1176,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/0",
@@ -1163,6 +1232,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1208,6 +1278,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -1363,33 +1434,45 @@
           }
         },
         "script_data_hash": null,
+        "collateral_inputs": [
+          {
+            "path": "m/1852'/1815'/0'/0/0",
+            "prev_hash": "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02",
+            "prev_index": 0
+          },
+          {
+            "path": "m/1852'/1815'/0'/0/1",
+            "prev_hash": "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02",
+            "prev_index": 0
+          }
+        ],
         "signing_mode": "ORDINARY_TRANSACTION"
       },
       "result": {
-        "tx_hash": "ee0dfef8b97857ebe7aa8935af50e9f8f608ff4054c0c034600750d722d90631",
+        "tx_hash": "3eaf37be6d7666161ab30f7428bc48f582e5f4ee7c78e8b575445e74499f3a73",
         "witnesses": [
           {
             "type": 1,
             "pub_key": "5d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1",
-            "signature": "7d17407e4e8f8b89f8794c022408a84e6f7ef163957d9d7e8ebee4cf9b5c87750c7c559f3a2663441535eec88ebce8540e7d7ea30897de984b1053b818374007",
+            "signature": "8ee6d98dd5ec26e32e66d5c6f3fe414e5051a71516af987d80b4bedbc4313de3a5360ae66f993a908b11692761bd7527fade3908c894a3ef803cfb5a0578e607",
             "chain_code": null
           },
           {
             "type": 1,
             "pub_key": "36a8ef21d5b98fdf23a27325cf643deaac35e912c835e35037f23d1061ae5b16",
-            "signature": "df62ec013a32d137c86931cec726d104cbc3193776026ec36d10450d9cbd289abc4c2d44311878b3aba035a8aec2c076522183027f9da046b586b5de5c460504",
+            "signature": "d312828d8f3c5a808c7a2174ae7ce45fe0fc80f64d6093ffd0ed2895b0e66478793c149cc1ad89b609403ef6a4c43a9d08797dcef63fe7df3cb60e557652ab05",
             "chain_code": null
           },
           {
             "type": 1,
             "pub_key": "e90d7b0a6cf831b0042d37961dd528842860e77914e715bcece676c75353b812",
-            "signature": "e249396d227f1d0540e58b64610bdb990eb1f1db9b3bae4a3d4a8088679af4a3bab464a5c912f7041a5fabc37e3009b3e1f4d76e2406429a0ebed85b880ecd0c",
+            "signature": "a057c923517c81013a25dad54000e26c3107bbb53b7a1da5427ee188f9ed01ec11ca973f919f4fa98c9f4068819afd53f05e3fc59ed9e573befe08ed2e1d6b01",
             "chain_code": null
           },
           {
             "type": 1,
             "pub_key": "bc65be1b0b9d7531778a1317c2aa6de936963c3f9ac7d5ee9e9eda25e0c97c5e",
-            "signature": "0dfd139ce3e255664a77de7d199ce5e4f1a1238ec17a6acec4aaae79be2ccd9b1d21127164c059c8aea2c4b91292aaf352c824550db7594b59e4eca6455d3f03",
+            "signature": "5d442be6ac738f496db9492b6e1ebc0c81d7e84cc2ac634dd0ab517b68f87df252fd6ce16d2a91b1781dbb0f56d7210296d8b5509233918692827fa91c55ba05",
             "chain_code": null
           }
         ],

--- a/common/tests/fixtures/cardano/sign_tx.slip39.json
+++ b/common/tests/fixtures/cardano/sign_tx.slip39.json
@@ -19,6 +19,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -57,6 +58,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",
@@ -100,6 +102,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/44'/1815'/0'/0/1",

--- a/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
+++ b/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
@@ -37,6 +37,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -91,6 +92,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -142,6 +144,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -193,6 +196,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -265,6 +269,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -299,6 +304,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -355,6 +361,7 @@
         ],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -405,6 +412,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": "m/1852'/1815'/0'/0/0",
@@ -456,6 +464,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -506,6 +515,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
@@ -589,6 +599,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -673,6 +684,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,

--- a/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.json
+++ b/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.json
@@ -69,6 +69,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -161,6 +162,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -254,6 +256,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -313,6 +316,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -372,6 +376,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -466,6 +471,7 @@
           "hash": "ea4c91860dd5ec5449f8f985d227946ff39086b17f10b5afb93d12ee87050b6a"
         },
         "script_data_hash": null,
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,
@@ -558,6 +564,7 @@
         "withdrawals": [],
         "auxiliary_data": null,
         "script_data_hash": "d593fd793c377ac50a3169bb8378ffc257c944da31aa8f355dfa5a4f6ff89e02",
+        "collateral_inputs": [],
         "inputs": [
           {
             "path": null,

--- a/core/src/apps/cardano/layout.py
+++ b/core/src/apps/cardano/layout.py
@@ -30,6 +30,7 @@ if False:
     from trezor.messages import (
         CardanoBlockchainPointerType,
         CardanoTxCertificate,
+        CardanoTxInput,
         CardanoTxWithdrawal,
         CardanoPoolParametersType,
         CardanoPoolOwner,
@@ -432,6 +433,22 @@ async def confirm_script_data_hash(ctx: wire.Context, script_data_hash: bytes) -
         title="Confirm transaction",
         props=[("Script data hash:", script_data_hash)],
         # TODO decide if the hash shouldn't be shown in bech32
+        br_code=ButtonRequestType.Other,
+    )
+
+
+async def confirm_collateral_input(
+    ctx: wire.Context, collateral_input: CardanoTxInput
+) -> None:
+    await confirm_properties(
+        ctx,
+        "confirm_collateral_input",
+        title="Confirm transaction",
+        props=[
+            ("Collateral input ID:", collateral_input.prev_hash),
+            # TODO decide if the hash shouldn't be shown in bech32
+            ("Collateral input index:", str(collateral_input.prev_index)),
+        ],
         br_code=ButtonRequestType.Other,
     )
 

--- a/core/src/trezor/messages.py
+++ b/core/src/trezor/messages.py
@@ -1158,6 +1158,7 @@ if TYPE_CHECKING:
         validity_interval_start: "int | None"
         witness_requests_count: "int"
         script_data_hash: "bytes | None"
+        collateral_inputs_count: "int"
 
         def __init__(
             self,
@@ -1172,6 +1173,7 @@ if TYPE_CHECKING:
             withdrawals_count: "int",
             has_auxiliary_data: "bool",
             witness_requests_count: "int",
+            collateral_inputs_count: "int",
             ttl: "int | None" = None,
             validity_interval_start: "int | None" = None,
             script_data_hash: "bytes | None" = None,

--- a/python/src/trezorlib/cardano.py
+++ b/python/src/trezorlib/cardano.py
@@ -513,6 +513,7 @@ def sign_tx(
     network_id: int = NETWORK_IDS["mainnet"],
     auxiliary_data: messages.CardanoTxAuxiliaryData = None,
     script_data_hash: Optional[bytes] = None,
+    collateral_inputs: List[InputWithPath] = (),
 ) -> SignTxResponse:
     UNEXPECTED_RESPONSE_ERROR = exceptions.TrezorException("Unexpected response")
 
@@ -533,6 +534,7 @@ def sign_tx(
             has_auxiliary_data=auxiliary_data is not None,
             witness_requests_count=len(witness_paths),
             script_data_hash=script_data_hash,
+            collateral_inputs_count=len(collateral_inputs),
         )
     )
     if not isinstance(response, messages.CardanoTxItemAck):
@@ -543,6 +545,7 @@ def sign_tx(
         _get_output_items(outputs),
         _get_certificate_items(certificates),
         withdrawals,
+        _get_input_items(collateral_inputs),
     ):
         response = client.call(tx_item)
         if not isinstance(response, messages.CardanoTxItemAck):

--- a/python/src/trezorlib/cli/cardano.py
+++ b/python/src/trezorlib/cli/cardano.py
@@ -77,6 +77,10 @@ def sign_tx(client, file, signing_mode, protocol_magic, network_id, testnet):
     script_data_hash = cardano.parse_script_data_hash(
         transaction.get("script_data_hash")
     )
+    collateral_inputs = [
+        cardano.parse_input(collateral_input)
+        for collateral_input in transaction.get("collateral_inputs", ())
+    ]
 
     sign_tx_response = cardano.sign_tx(
         client,
@@ -92,6 +96,7 @@ def sign_tx(client, file, signing_mode, protocol_magic, network_id, testnet):
         network_id,
         auxiliary_data,
         script_data_hash,
+        collateral_inputs,
     )
 
     sign_tx_response["tx_hash"] = sign_tx_response["tx_hash"].hex()

--- a/python/src/trezorlib/messages.py
+++ b/python/src/trezorlib/messages.py
@@ -1967,6 +1967,7 @@ class CardanoSignTxInit(protobuf.MessageType):
         11: protobuf.Field("validity_interval_start", "uint64", repeated=False, required=False),
         12: protobuf.Field("witness_requests_count", "uint32", repeated=False, required=True),
         13: protobuf.Field("script_data_hash", "bytes", repeated=False, required=False),
+        14: protobuf.Field("collateral_inputs_count", "uint32", repeated=False, required=True),
     }
 
     def __init__(
@@ -1982,6 +1983,7 @@ class CardanoSignTxInit(protobuf.MessageType):
         withdrawals_count: "int",
         has_auxiliary_data: "bool",
         witness_requests_count: "int",
+        collateral_inputs_count: "int",
         ttl: Optional["int"] = None,
         validity_interval_start: Optional["int"] = None,
         script_data_hash: Optional["bytes"] = None,
@@ -1996,6 +1998,7 @@ class CardanoSignTxInit(protobuf.MessageType):
         self.withdrawals_count = withdrawals_count
         self.has_auxiliary_data = has_auxiliary_data
         self.witness_requests_count = witness_requests_count
+        self.collateral_inputs_count = collateral_inputs_count
         self.ttl = ttl
         self.validity_interval_start = validity_interval_start
         self.script_data_hash = script_data_hash

--- a/tests/device_tests/cardano/test_sign_tx.py
+++ b/tests/device_tests/cardano/test_sign_tx.py
@@ -41,6 +41,9 @@ def test_cardano_sign_tx(client, parameters, result):
     withdrawals = [cardano.parse_withdrawal(w) for w in parameters["withdrawals"]]
     auxiliary_data = cardano.parse_auxiliary_data(parameters["auxiliary_data"])
     script_data_hash = cardano.parse_script_data_hash(parameters["script_data_hash"])
+    collateral_inputs = [
+        cardano.parse_input(i) for i in parameters["collateral_inputs"]
+    ]
 
     if parameters.get("security_checks") == "prompt":
         device.apply_settings(
@@ -64,6 +67,7 @@ def test_cardano_sign_tx(client, parameters, result):
             network_id=parameters["network_id"],
             auxiliary_data=auxiliary_data,
             script_data_hash=script_data_hash,
+            collateral_inputs=collateral_inputs,
         )
         assert response == _transform_expected_result(result)
 
@@ -79,6 +83,9 @@ def test_cardano_sign_tx_failed(client, parameters, result):
     withdrawals = [cardano.parse_withdrawal(w) for w in parameters["withdrawals"]]
     auxiliary_data = cardano.parse_auxiliary_data(parameters["auxiliary_data"])
     script_data_hash = cardano.parse_script_data_hash(parameters["script_data_hash"])
+    collateral_inputs = [
+        cardano.parse_input(i) for i in parameters["collateral_inputs"]
+    ]
 
     with client:
         with pytest.raises(TrezorFailure, match=result["error_message"]):
@@ -96,6 +103,7 @@ def test_cardano_sign_tx_failed(client, parameters, result):
                 network_id=parameters["network_id"],
                 auxiliary_data=auxiliary_data,
                 script_data_hash=script_data_hash,
+                collateral_inputs=collateral_inputs,
             )
 
 


### PR DESCRIPTION
TODOs:
- make sure we don't need a separate `CollateralInput` protobuf message
- re-consider the `confirm_collateral_input` wording
- use proper signing mode
- how will collateral inputs be witnessed - determined by client or passed in via additional witnesses?
- TODOs in the code
