### PR TITLE
feat(cardano): validate pool registration owner witness path

### DIFF
--- a/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
+++ b/common/tests/fixtures/cardano/sign_tx_stake_pool_registration.failed.json
@@ -429,7 +429,7 @@
         "additional_witness_requests": []
       },
       "result": {
-        "error_message": "Stakepool registration transaction can only contain staking witnesses"
+        "error_message": "Stakepool registration transaction can only contain sinlge staking witnesses with the same path as in the certificate"
       }
     },
     {
@@ -790,7 +790,7 @@
         ]
       },
       "result": {
-        "error_message": "Stakepool registration transaction can only contain staking witnesses"
+        "error_message": "Stakepool registration transaction can only contain sinlge staking witnesses with the same path as in the certificate"
       }
     },
     {
@@ -879,7 +879,96 @@
         ]
       },
       "result": {
-        "error_message": "Stakepool registration transaction can only contain staking witnesses"
+        "error_message": "Stakepool registration transaction can only contain sinlge staking witnesses with the same path as in the certificate"
+      }
+    },
+    {
+      "description": "Sample stake pool registration certificate with additional witness request with different staking path",
+      "parameters": {
+        "protocol_magic": 764824073,
+        "network_id": 1,
+        "fee": 42,
+        "ttl": 10,
+        "certificates": [
+          {
+            "type": 3,
+            "pool_parameters": {
+              "pool_id": "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
+              "vrf_key_hash": "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
+              "pledge": 500000000,
+              "cost": 340000000,
+              "margin": {
+                "numerator": 1,
+                "denominator": 2
+              },
+              "reward_account": "stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el",
+              "owners": [
+                {
+                  "staking_key_path": "m/1852'/1815'/0'/2/0"
+                },
+                {
+                  "staking_key_hash": "3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711"
+                }
+              ],
+              "relays": [
+                {
+                  "type": 0,
+                  "ipv4_address": "192.168.0.1",
+                  "ipv6_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                  "port": 1234
+                },
+                {
+                  "type": 0,
+                  "ipv6_address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                  "port": 1234
+                },
+                {
+                  "type": 0,
+                  "ipv4_address": "192.168.0.1",
+                  "port": 1234
+                },
+                {
+                  "type": 1,
+                  "host_name": "www.test.test",
+                  "port": 1234
+                },
+                {
+                  "type": 2,
+                  "host_name": "www.test2.test"
+                }
+              ],
+              "metadata": {
+                "url": "https://www.test.test",
+                "hash": "914c57c1f12bbf4a82b12d977d4f274674856a11ed4b9b95bd70f5d41c5064a6"
+              }
+            }
+          }
+        ],
+        "withdrawals": [],
+        "auxiliary_data": null,
+        "inputs": [
+          {
+            "path": null,
+            "prev_hash": "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7",
+            "prev_index": 0
+          }
+        ],
+        "outputs": [
+          {
+            "address": "addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r",
+            "amount": "1"
+          }
+        ],
+        "mint": [],
+        "signing_mode": "POOL_REGISTRATION_AS_OWNER",
+        "additional_witness_requests": [
+          {
+            "path": "m/1852'/1815'/0'/2/1"
+          }
+        ]
+      },
+      "result": {
+        "error_message": "Stakepool registration transaction can only contain sinlge staking witnesses with the same path as in the certificate"
       }
     },
     {

--- a/core/src/all_modules.py
+++ b/core/src/all_modules.py
@@ -466,6 +466,8 @@ if utils.BITCOIN_ONLY:
     import apps.cardano.helpers.network_ids
     apps.cardano.helpers.paths
     import apps.cardano.helpers.paths
+    apps.cardano.helpers.pool_owner_path_check
+    import apps.cardano.helpers.pool_owner_path_check
     apps.cardano.helpers.protocol_magics
     import apps.cardano.helpers.protocol_magics
     apps.cardano.helpers.utils

--- a/core/src/apps/cardano/helpers/__init__.py
+++ b/core/src/apps/cardano/helpers/__init__.py
@@ -12,8 +12,8 @@ INVALID_AUXILIARY_DATA = wire.ProcessError("Invalid auxiliary data")
 INVALID_STAKE_POOL_REGISTRATION_TX_STRUCTURE = wire.ProcessError(
     "Stakepool registration transaction cannot contain other certificates, withdrawals or minting"
 )
-INVALID_STAKEPOOL_REGISTRATION_TX_WITNESSES = wire.ProcessError(
-    "Stakepool registration transaction can only contain staking witnesses"
+INVALID_STAKEPOOL_REGISTRATION_TX_WITNESS = wire.ProcessError(
+    "Stakepool registration transaction can only contain sinlge staking witnesses with the same path as in the certificate"
 )
 INVALID_WITNESS_REQUEST = wire.ProcessError("Invalid witness request")
 INVALID_NATIVE_SCRIPT = wire.ProcessError("Invalid native script")

--- a/core/src/apps/cardano/helpers/pool_owner_path_check.py
+++ b/core/src/apps/cardano/helpers/pool_owner_path_check.py
@@ -1,0 +1,40 @@
+from . import INVALID_CERTIFICATE, INVALID_STAKEPOOL_REGISTRATION_TX_WITNESS
+from .paths import SCHEMA_STAKING_ANY_ACCOUNT
+
+
+class PoolOwnerPathChecker:
+    """
+    We have a separate tx signing flow for stake pool registration because it's a
+    transaction where the witnessable entries (i.e. inputs, withdrawals, etc.)
+    in the transaction are not supposed to be controlled by the HW wallet, which
+    means the user is vulnerable to unknowingly supplying a witness for an UTXO
+    or other tx entry they think is external, resulting in the co-signers
+    gaining control over their funds (Something SLIP-0019 is dealing with for
+    BTC but no similar standard is currently available for Cardano). Hence we
+    completely forbid witnessing inputs and other entries of the transaction
+    except the stake pool certificate itself and we provide a witness only to the
+    user's staking key in the list of pool owners.
+
+    This class ensures that:
+        - there is exactly one path in the pool owners list
+        - the witness request path is a staking path
+        - the two mentioned paths are the same
+    """
+
+    def __init__(self) -> None:
+        self.path: list[int] | None = None
+
+    def add(self, path: list[int]) -> None:
+        if self.path is not None:
+            raise INVALID_CERTIFICATE
+        self.path = path
+
+    def check_if_added(self) -> None:
+        if self.path is None:
+            raise INVALID_CERTIFICATE
+
+    def check_witness_request(self, path: list[int]) -> None:
+        if not SCHEMA_STAKING_ANY_ACCOUNT.match(path):
+            raise INVALID_STAKEPOOL_REGISTRATION_TX_WITNESS
+        if self.path != path:
+            raise INVALID_STAKEPOOL_REGISTRATION_TX_WITNESS


### PR DESCRIPTION
Adds validation of witness request path against the path in the pool registration certificate, as proposed by @janmazak.